### PR TITLE
Django 2.0.x compatibility, improve tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ cover/
 .cache/
 htmlcov/
 coverage.xml
+/.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 install: travis_retry pip install -U codecov tox-travis

--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -15,7 +15,6 @@ from django.utils.translation import ugettext_lazy as _
 from celery import current_app
 from celery import states
 from celery.task.control import broadcast, revoke, rate_limit
-from celery.utils.text import abbrtask
 
 from .models import TaskState, WorkerState
 from .humanize import naturaldate
@@ -87,7 +86,9 @@ def tstamp(task):
 @display_field(_('name'), 'name')
 def name(task):
     """Return the task name and abbreviates it to maximum of 16 characters."""
-    short_name = abbrtask(task.name, 16)
+    short_name = task.name
+    if task.name and len(task.name) > 16:
+        short_name = format_html('{0}&hellip;', task.name[0:15])
     return format_html('<div title="{0}"><b>{1}</b></div>', task.name,
                        short_name)
 

--- a/django_celery_monitor/utils.py
+++ b/django_celery_monitor/utils.py
@@ -9,7 +9,8 @@ from pprint import pformat
 from django.conf import settings
 from django.db.models import DateTimeField, Func
 from django.utils import timezone
-from django.utils.html import mark_safe, format_html
+from django.utils.html import format_html
+from six import string_types
 
 try:
     from django.db.models.functions import Now
@@ -92,11 +93,17 @@ def action(short_description, **kwargs):
 
 
 def fixedwidth(field, name=None, pt=6, width=16, maxlen=64, pretty=False):
-    """Render a field with a fixed width."""
+    """Render a field with a fixed width.
+
+    :param bool pretty:
+        For field values that are not a string, use pretty printing if True.
+    """
     @display_field(name or field, field)
     def f(task):
         val = getattr(task, field)
-        if pretty:
+
+        # Pretty printing only makes sense for things that aren't strings
+        if not isinstance(val, string_types) and pretty:
             val = pformat(val, width=width)
         if val.startswith("u'") or val.startswith('u"'):
             val = val[2:-1]
@@ -105,6 +112,5 @@ def fixedwidth(field, name=None, pt=6, width=16, maxlen=64, pretty=False):
 
         if len(shortval) > maxlen:
             shortval = shortval[:maxlen] + '...'
-        return format_html(FIXEDWIDTH_STYLE, val[:255], pt,
-                           mark_safe(shortval))
+        return format_html(FIXEDWIDTH_STYLE, val[:255], pt, shortval)
     return f

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,9 @@ case>=1.3.1
 pytest>=3.0
 pytest-django==3.1.2
 pytz>dev
+
+# Allows freezing of current time in tests
+freezegun==0.3.9
+
+# Provides unittest.mock when running the test suite on Python 2
+mock==2.0.0

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import, unicode_literals
+
+from datetime import datetime
+from unittest import TestCase
+from mock import Mock
+
+from freezegun import freeze_time
+
+from django_celery_monitor.admin import colored_state, node_state, eta,\
+    tstamp, name
+
+
+class ColoredStateTest(TestCase):
+    def test_success(self):
+        """Rendering of a sucessful task's state."""
+        mock_task = Mock()
+        mock_task.state = 'SUCCESS'
+        expected_html = '<b><span style="color: green;">SUCCESS</span></b>'
+        assert colored_state(mock_task) == expected_html
+
+
+class NodeStateTest(TestCase):
+    def test_online(self):
+        """Rendering of an online node's state."""
+        mock_node = Mock()
+        mock_node.is_alive.return_value = True
+        expected_html = '<b><span style="color: green;">ONLINE</span></b>'
+        assert node_state(mock_node) == expected_html
+
+
+class ETATest(TestCase):
+    def test_eta_value_not_set(self):
+        """Rendering when no ETA is specified by the task."""
+        mock_task = Mock()
+        mock_task.eta = None
+        expected_html = '<span style="color: gray;">none</span>'
+        assert eta(mock_task) == expected_html
+
+    def test_eta_value_set(self):
+        """Rendering when an ETA value is set by the task."""
+        mock_task = Mock()
+        mock_task.eta = datetime(2020, 1, 2, 8, 35)
+        expected_html = '2020-01-02 08:35:00+00:00'
+        assert eta(mock_task) == expected_html
+
+
+class TStampTest(TestCase):
+    def test_time_difference_of_roughly_two_years(self):
+        """Timestamp is roughly two years into the past."""
+        mock_task = Mock()
+        mock_task.tstamp = datetime(2015, 8, 5, 17, 3)
+        expected_html = '<div title="2015-08-05 17:03:00+00:00">2 years ago' \
+                        '</div>'
+        with freeze_time(datetime(2017, 8, 6)):
+            assert tstamp(mock_task) == expected_html
+
+
+class NameTest(TestCase):
+    def test_no_more_than_16_characters(self):
+        """
+        No truncation should happen on names that are at most 16 characters in
+        length.
+        """
+        mock_task = Mock()
+        mock_task.name = '1234567890123456'
+        expected_html = '<div title="1234567890123456"><b>1234567890123456' \
+                        '</b></div>'
+        assert name(mock_task) == expected_html
+
+    def test_more_than_16_characters(self):
+        """Truncation should happen above 16 characters."""
+        mock_task = Mock()
+        mock_task.name = '12345678901234567'
+        expected_html = '<div title="12345678901234567"><b>123456789012345' \
+                        '&hellip;</b></div>'
+        assert name(mock_task) == expected_html

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, unicode_literals
+
+from re import match
+from unittest import TestCase
+
+from mock import Mock
+
+from django_celery_monitor.utils import fixedwidth
+
+
+class FixedWidthTest(TestCase):
+    def test_unpretty_string(self):
+        """Do not request pretty printing for a string."""
+        task_mock = Mock()
+        task_mock.name = 'testing'
+        expected_html = '<span title="testing" style="font-size: 6pt; font-' \
+                        'family: Menlo, Courier; ">testing</span> '
+        assert fixedwidth('name')(task_mock) == expected_html
+
+    def test_pretty_string(self):
+        """Request pretty printed value for a string."""
+        task_mock = Mock()
+        task_mock.name = 'testing'
+        expected_html = ('<span title="testing" style="font-size:'
+                         ' 6pt; font-family: Menlo, Courier; ">testing'
+                         '</span> ')
+        assert fixedwidth('name', pretty=True)(task_mock) == expected_html
+
+    def test_pretty_object(self):
+        """Request pretty printed value for an object."""
+        task_mock = Mock()
+        task_mock.name = object()
+        actual_html = fixedwidth('name', pretty=True)(task_mock)
+        matcher = match(
+            '<span title="&lt;object object at 0x[0-9a-f]+&gt;" style="'
+            'font-size: 6pt; font-family: Menlo, Courier; ">'
+            '&lt;object object at 0x[0-9a-f]+&gt;</span> ',
+            actual_html,
+        )
+        assert matcher

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     tests-py{py,27,34,35}-dj{18,19,110}
-    tests-py36-dj111
+    tests-py{27,35,36}-dj111
     tests-py{35,36}-dj20
     apicheck
     builddocs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    tests-py{py,27,34,35}-dj{18,19,110}
     tests-py{27,35,36}-dj111
     tests-py{35,36}-dj20
     apicheck
@@ -25,9 +24,6 @@ deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/test-ci.txt
 
-    dj18: django>=1.8,<1.9
-    dj19: django>=1.9,<1.10
-    dj110: django>=1.10,<1.11
     dj111: django>=1.11,<2
     dj20: django>=2.0,<2.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     tests-py{py,27,34,35}-dj{18,19,110}
     tests-py36-dj111
+    tests-py{35,36}-dj20
     apicheck
     builddocs
     flake8
@@ -28,6 +29,7 @@ deps=
     dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
     dj111: django>=1.11,<2
+    dj20: django>=2.0,<2.1
 
     apicheck,builddocs,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,flakeplus,manifest,pydocstyle,readme: -r{toxinidir}/requirements/pkgutils.txt


### PR DESCRIPTION
Note that the Python 3.5 build fails because it looks like it tries and fails to upload coverage that's intended to be used with the upstream repo jezdez/django-celery-monitor. The rest of that build looks fine:

```
  tests-py35-dj111: commands succeeded
  tests-py35-dj20: commands succeeded
  congratulations :)
```